### PR TITLE
Fix turret firing and aiming issues on dedicated servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Ever wanted a good turret mod, but you couldn't find any? Ever wanted one that i
 
 This mod adds turrets that use guns from TACZ. Simply click it with a gun, or drop it near the turret. Clicking a turret that has a gun will take the gun and ammo. The turret has a light on both sides, if it's green then it's good to go, yellow means reloading, bright red is out of ammo and dark red means no gun equipped.
 
-The config currently has one value that controls whether turrets require ammo. If it's off, then it can fire indefinitely. If it is on, the turret will need the correct type of ammo for the gun. This can be provided either by clicking it, dropping the ammo near it, or putting the ammo in a chest directly under the turret.
+The config has the following options:
+
+- **consumeAmmo** — Whether turrets require ammo. If off, turrets fire indefinitely. If on, the turret needs the correct ammo type for its gun, which can be provided by clicking the turret, dropping ammo near it, or placing it in a chest directly under the turret.
+- **turretRange** — Detection and engagement range in blocks (default 64, min 8, max 128).
+- **turretHealth** — Initial health for newly placed turrets (default 200, min 10, max 1000). Does not affect existing turrets.
+- **targetAllMobs** — If true, turrets target all living entities except players, other turrets, and the owner. If false, turrets only target vanilla monsters and entities added to the `tacz_turrets:turret_targets` entity type tag. Entities in the `tacz_turrets:turret_ignored` tag are never targeted regardless of this setting.
 
 Based off of the [TACZ NPCS](https://modrinth.com/mod/tacz-npcs) mod, borrows lots of code from it. Huge thanks to Corrinedev for making an open-source mod!

--- a/src/main/java/com/entropy/tacz_turrets/common/entity/TaczShootAttack.java
+++ b/src/main/java/com/entropy/tacz_turrets/common/entity/TaczShootAttack.java
@@ -6,6 +6,7 @@ import com.tacz.guns.item.ModernKineticGunItem;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.commands.arguments.EntityAnchorArgument;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.behavior.BehaviorUtils;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
@@ -42,7 +43,8 @@ public class TaczShootAttack<E extends TurretEntity> extends ExtendedBehaviour<E
         LivingEntity target = this.target;
         if (target != null
                 && BehaviorUtils.entityIsVisible(entity.getBrain(), target)) {
-            entity.lookAt(EntityAnchorArgument.Anchor.EYES, target.getPosition(1f));
+            Vec3 center = target.getBoundingBox().getCenter();
+            entity.lookAt(EntityAnchorArgument.Anchor.EYES, center);
             BehaviorUtils.lookAtEntity(entity, target);
             if (entity.hasLineOfSight(target)) {
                 if (entity.getMainHandItem().getItem() instanceof ModernKineticGunItem) {

--- a/src/main/java/com/entropy/tacz_turrets/common/entity/TaczShootAttack.java
+++ b/src/main/java/com/entropy/tacz_turrets/common/entity/TaczShootAttack.java
@@ -34,7 +34,7 @@ public class TaczShootAttack<E extends TurretEntity> extends ExtendedBehaviour<E
     @Override
     protected boolean checkExtraStartConditions(@NotNull ServerLevel level, @NotNull E entity) {
         this.target = BrainUtils.getTargetOfEntity(entity);
-        return target != null && BrainUtils.canSee(entity, this.target) && !target.getUUID().equals(entity.owner)
+        return target != null && BrainUtils.canSee(entity, this.target) && !target.getUUID().equals(entity.owner);
     }
 
     @Override

--- a/src/main/java/com/entropy/tacz_turrets/common/entity/TurretEntity.java
+++ b/src/main/java/com/entropy/tacz_turrets/common/entity/TurretEntity.java
@@ -222,6 +222,7 @@ public class TurretEntity extends Mob implements SmartBrainOwner<TurretEntity>, 
                         new InvalidateAttackTarget<>()
                                 .invalidateIf((entity, target) -> !target.isAlive()
                                         || (target instanceof Player player && player.getAbilities().invulnerable)
+                                        || !entity.hasLineOfSight(target)
                                         || entity.distanceToSqr(target) > TACZTurretsConfig.turretRange
                                                 * TACZTurretsConfig.turretRange)
                                 .ignoreFailedPathfinding(),

--- a/src/main/java/com/entropy/tacz_turrets/common/entity/TurretEntity.java
+++ b/src/main/java/com/entropy/tacz_turrets/common/entity/TurretEntity.java
@@ -41,6 +41,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.behavior.Behavior;
 import net.minecraft.world.entity.ai.behavior.BehaviorUtils;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.Monster;
 import net.minecraft.world.entity.player.Player;
@@ -65,6 +66,8 @@ import net.tslat.smartbrainlib.api.core.sensor.ExtendedSensor;
 import net.tslat.smartbrainlib.api.core.sensor.vanilla.HurtBySensor;
 import net.tslat.smartbrainlib.api.core.sensor.vanilla.NearbyLivingEntitySensor;
 import net.tslat.smartbrainlib.api.core.sensor.vanilla.NearbyPlayersSensor;
+import net.tslat.smartbrainlib.util.BrainUtils;
+
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Unique;
 import software.bernie.geckolib.animatable.GeoEntity;
@@ -216,7 +219,12 @@ public class TurretEntity extends Mob implements SmartBrainOwner<TurretEntity>, 
     public BrainActivityGroup<? extends TurretEntity> getFightTasks() {
         return BrainActivityGroup
                 .fightTasks(new Behavior[] {
-                        new InvalidateAttackTarget<>(),
+                        new InvalidateAttackTarget<>()
+                                .invalidateIf((entity, target) -> !target.isAlive()
+                                        || (target instanceof Player player && player.getAbilities().invulnerable)
+                                        || entity.distanceToSqr(target) > TACZTurretsConfig.turretRange
+                                                * TACZTurretsConfig.turretRange)
+                                .ignoreFailedPathfinding(),
                         new SetRetaliateTarget<>(),
                         new TaczShootAttack<>(TACZTurretsConfig.turretRange)
                                 .startCondition((x$0) -> this.getMainHandItem().is(ModItems.MODERN_KINETIC_GUN.get())
@@ -225,13 +233,14 @@ public class TurretEntity extends Mob implements SmartBrainOwner<TurretEntity>, 
 
     @Override
     public List<? extends ExtendedSensor<? extends TurretEntity>> getSensors() {
+        int range = TACZTurretsConfig.turretRange > 0 ? TACZTurretsConfig.turretRange : 64;
         return ObjectArrayList.of(
                 new NearbyPlayersSensor<TurretEntity>()
-                        .setRadius(TACZTurretsConfig.turretRange)
+                        .setRadius(range)
                         .setPredicate((p, e) -> e.attackers.contains(p)),
                 new HurtBySensor<>(),
                 new NearbyLivingEntitySensor<TurretEntity>()
-                        .setRadius(TACZTurretsConfig.turretRange)
+                        .setRadius(range)
                         .setPredicate((target, entity) -> {
                             if (target == entity || !target.isAlive())
                                 return false;


### PR DESCRIPTION
## Dedicated server targeting fix

Turrets were not firing at targets on dedicated servers. The root cause was `InvalidateAttackTarget` clearing the `ATTACK_TARGET` brain memory every tick for two reasons:

1. Its default predicate invalidates targets beyond `FOLLOW_RANGE` (32 blocks), but the sensor scans up to the configured `turretRange`. So the sensor would find a target, `TargetOrRetaliate` would set it as the attack target, and `InvalidateAttackTarget` would immediately clear it because the target was beyond `FOLLOW_RANGE`.

2. Its default pathfinding timeout invalidates targets after 200 ticks if the entity can't pathfind to them. Since turrets are stationary and never pathfind, this would eventually invalidate every target.

This caused a rapid set/clear cycle on `ATTACK_TARGET` that prevented `TaczShootAttack` from ever firing. The fix replaces the default distance check with one using the config range and disables the pathfinding timeout via `.ignoreFailedPathfinding()`.

Also added a fallback in `getSensors()` so that if the config hasn't loaded yet, the sensor defaults to 64 blocks instead of 0.

## Aim point fix

Closes #6

The turret was aiming at `target.getPosition()` which returns the entity's foot position. This caused bullets to hit the ground in front of targets, especially at range due to bullet drop. Changed the aim point to the center of the target's bounding box.